### PR TITLE
Feature: MQTT SSL Certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Specify filepatterns you want git to ignore.
 
+.DS_STORE

--- a/bluetooth.ino
+++ b/bluetooth.ino
@@ -16,10 +16,10 @@ class MyServerCallbacks: public BLEServerCallbacks {
 class MyCallbacks: public BLECharacteristicCallbacks {
     void onWrite(BLECharacteristic *pCharacteristic) {
       std::string rxValue = pCharacteristic->getValue();
-      char rxBuffer[1000];
+      char rxBuffer[2100];
 
       if (rxValue.length() > 0) {
-        if (rxValue.length() > 999)
+        if (rxValue.length() > 2099)
           return;
         for (int i = 0; i < rxValue.length(); i++) {
           rxBuffer[i] = rxValue[i];
@@ -591,24 +591,56 @@ class MyCallbacks: public BLECharacteristicCallbacks {
         }
 
         //**************************************
-        char *keyWordmqssl = strstr(rxBuffer, "#mqssl");
-        if (keyWordmqssl != NULL) {
+        char *keyWordmqsslke = strstr(rxBuffer, "#mqsslke");
+        if (keyWordmqsslke != NULL) {
           const char delimiter[] = ",";
-          char parsedStrings[4][2000];
+          char parsedStrings[2][2000];
           char *token =  strtok(rxBuffer, delimiter);
           strncpy(parsedStrings[0], token, sizeof(parsedStrings[0]));//first one
-          for (int i = 1; i < 4; i++) {
+          for (int i = 1; i < 2; i++) {
             token =  strtok(NULL, delimiter);
             strncpy(parsedStrings[i], token, sizeof(parsedStrings[i]));
           }
           strlcpy(config.mqttSSLKey,                  // <- destination
                   parsedStrings[1],  // <- source
                   sizeof(config.mqttSSLKey));         // <- destination's capacity
+
+          saveConfiguration(filename, config);
+          sendParam = true;
+        }
+
+        //**************************************
+        char *keyWordmqsslce = strstr(rxBuffer, "#mqsslce");
+        if (keyWordmqsslce != NULL) {
+          const char delimiter[] = ",";
+          char parsedStrings[2][2000];
+          char *token =  strtok(rxBuffer, delimiter);
+          strncpy(parsedStrings[0], token, sizeof(parsedStrings[0]));//first one
+          for (int i = 1; i < 2; i++) {
+            token =  strtok(NULL, delimiter);
+            strncpy(parsedStrings[i], token, sizeof(parsedStrings[i]));
+          }
           strlcpy(config.mqttSSLCert,                  // <- destination
-                  parsedStrings[2],  // <- source
+                  parsedStrings[1],  // <- source
                   sizeof(config.mqttSSLCert));         // <- destination's capacity
+          
+          saveConfiguration(filename, config);
+          sendParam = true;
+        }
+
+        //**************************************
+        char *keyWordmqsslca = strstr(rxBuffer, "#mqsslca");
+        if (keyWordmqsslca != NULL) {
+          const char delimiter[] = ",";
+          char parsedStrings[2][2000];
+          char *token =  strtok(rxBuffer, delimiter);
+          strncpy(parsedStrings[0], token, sizeof(parsedStrings[0]));//first one
+          for (int i = 1; i < 2; i++) {
+            token =  strtok(NULL, delimiter);
+            strncpy(parsedStrings[i], token, sizeof(parsedStrings[i]));
+          }
           strlcpy(config.mqttSSLCA,                  // <- destination
-                  parsedStrings[3],  // <- source
+                  parsedStrings[1],  // <- source
                   sizeof(config.mqttSSLCA));         // <- destination's capacity
 
           saveConfiguration(filename, config);

--- a/bluetooth.ino
+++ b/bluetooth.ino
@@ -591,6 +591,31 @@ class MyCallbacks: public BLECharacteristicCallbacks {
         }
 
         //**************************************
+        char *keyWordmqssl = strstr(rxBuffer, "#mqssl");
+        if (keyWordmqssl != NULL) {
+          const char delimiter[] = ",";
+          char parsedStrings[4][2000];
+          char *token =  strtok(rxBuffer, delimiter);
+          strncpy(parsedStrings[0], token, sizeof(parsedStrings[0]));//first one
+          for (int i = 1; i < 4; i++) {
+            token =  strtok(NULL, delimiter);
+            strncpy(parsedStrings[i], token, sizeof(parsedStrings[i]));
+          }
+          strlcpy(config.mqttSSLKey,                  // <- destination
+                  parsedStrings[1],  // <- source
+                  sizeof(config.mqttSSLKey));         // <- destination's capacity
+          strlcpy(config.mqttSSLCert,                  // <- destination
+                  parsedStrings[2],  // <- source
+                  sizeof(config.mqttSSLCert));         // <- destination's capacity
+          strlcpy(config.mqttSSLCA,                  // <- destination
+                  parsedStrings[3],  // <- source
+                  sizeof(config.mqttSSLCA));         // <- destination's capacity
+
+          saveConfiguration(filename, config);
+          sendParam = true;
+        }
+
+        //**************************************
         char *keyWordmqsen = strstr(rxBuffer, "#mqsen");
         if (keyWordmqsen != NULL) {
           strlcpy(config.mqttSecureEnable,                  // <- destination
@@ -1155,6 +1180,12 @@ void serviceBluetooth() {
     transmitData("mqsu", config.mqttUser);
     delay(25);
     transmitData("mqsp", config.mqttPW);
+    delay(25);
+    transmitData("mqsske", config.mqttSSLKey);
+    delay(25);
+    transmitData("mqssce", config.mqttSSLCert);
+    delay(25);
+    transmitData("mqssca", config.mqttSSLCA);
     delay(25);
     transmitData("sipen", config.staticIPenable);
     delay(25);

--- a/bluetooth.ino
+++ b/bluetooth.ino
@@ -16,10 +16,10 @@ class MyServerCallbacks: public BLEServerCallbacks {
 class MyCallbacks: public BLECharacteristicCallbacks {
     void onWrite(BLECharacteristic *pCharacteristic) {
       std::string rxValue = pCharacteristic->getValue();
-      char rxBuffer[2100];
+      char rxBuffer[600];
 
       if (rxValue.length() > 0) {
-        if (rxValue.length() > 2099)
+        if (rxValue.length() > 599)
           return;
         for (int i = 0; i < rxValue.length(); i++) {
           rxBuffer[i] = rxValue[i];
@@ -593,60 +593,86 @@ class MyCallbacks: public BLECharacteristicCallbacks {
         //**************************************
         char *keyWordmqsslke = strstr(rxBuffer, "#mqsslke");
         if (keyWordmqsslke != NULL) {
+          Serial.println("Got part of a key");
           const char delimiter[] = ",";
-          char parsedStrings[2][2000];
+          char parsedStrings[3][600];
           char *token =  strtok(rxBuffer, delimiter);
+          Serial.println("DEBUG1");
           strncpy(parsedStrings[0], token, sizeof(parsedStrings[0]));//first one
-          for (int i = 1; i < 2; i++) {
+          Serial.println("DEBUG2");
+          for (int i = 1; i < 3; i++) {
             token =  strtok(NULL, delimiter);
             strncpy(parsedStrings[i], token, sizeof(parsedStrings[i]));
           }
-          strlcpy(config.mqttSSLKey,                  // <- destination
-                  parsedStrings[1],  // <- source
-                  sizeof(config.mqttSSLKey));         // <- destination's capacity
+          Serial.println("DEBUG3");
+          if(strcmp(parsedStrings[1], "w") == 0) {
+            Serial.println("DEBUG4");
+            strlcpy(mqttSSLKey,                  // <- destination
+                  parsedStrings[2],  // <- source
+                  sizeof(mqttSSLKey));         // <- destination's capacity
+          } else {
+            //add some logic in here to resend all params when done
+            Serial.println("DEBUG5");
+            strlcat(mqttSSLKey,                  // <- destination
+                  parsedStrings[2],  // <- source
+                  sizeof(mqttSSLKey));         // <- destination's capacity
+          }
+          Serial.println("DEBUG6");
 
-          saveConfiguration(filename, config);
-          sendParam = true;
+          saveKeyFile(mqttKeyFile, mqttSSLKey);
+          //sendParam = true;
         }
-
+        
         //**************************************
         char *keyWordmqsslce = strstr(rxBuffer, "#mqsslce");
         if (keyWordmqsslce != NULL) {
           const char delimiter[] = ",";
-          char parsedStrings[2][2000];
+          char parsedStrings[3][600];
           char *token =  strtok(rxBuffer, delimiter);
           strncpy(parsedStrings[0], token, sizeof(parsedStrings[0]));//first one
-          for (int i = 1; i < 2; i++) {
+          for (int i = 1; i < 3; i++) {
             token =  strtok(NULL, delimiter);
             strncpy(parsedStrings[i], token, sizeof(parsedStrings[i]));
           }
-          strlcpy(config.mqttSSLCert,                  // <- destination
-                  parsedStrings[1],  // <- source
-                  sizeof(config.mqttSSLCert));         // <- destination's capacity
+          if(strcmp(parsedStrings[1], "w") == 0) {
+            strlcpy(mqttSSLCert,                  // <- destination
+                  parsedStrings[2],  // <- source
+                  sizeof(mqttSSLCert));
+          } else {
+            strlcat(mqttSSLCert,                  // <- destination
+                  parsedStrings[2],  // <- source
+                  sizeof(mqttSSLCert));         // <- destination's capacity
+          }
           
-          saveConfiguration(filename, config);
-          sendParam = true;
+          saveKeyFile(mqttCertFile, mqttSSLCert);
+          //sendParam = true;
         }
-
+        
         //**************************************
         char *keyWordmqsslca = strstr(rxBuffer, "#mqsslca");
         if (keyWordmqsslca != NULL) {
           const char delimiter[] = ",";
-          char parsedStrings[2][2000];
+          char parsedStrings[3][600];
           char *token =  strtok(rxBuffer, delimiter);
           strncpy(parsedStrings[0], token, sizeof(parsedStrings[0]));//first one
-          for (int i = 1; i < 2; i++) {
+          for (int i = 1; i < 3; i++) {
             token =  strtok(NULL, delimiter);
             strncpy(parsedStrings[i], token, sizeof(parsedStrings[i]));
           }
-          strlcpy(config.mqttSSLCA,                  // <- destination
-                  parsedStrings[1],  // <- source
-                  sizeof(config.mqttSSLCA));         // <- destination's capacity
-
-          saveConfiguration(filename, config);
-          sendParam = true;
+          if(strcmp(parsedStrings[1], "w") == 0) {
+            strlcpy(mqttSSLCA,                  // <- destination
+                  parsedStrings[2],  // <- source
+                  sizeof(mqttSSLCA));         // <- destination's capacity
+          } else {
+            strlcat(mqttSSLCA,                  // <- destination
+                  parsedStrings[2],  // <- source
+                  sizeof(mqttSSLCA));         // <- destination's capacity
+          }
+          
+          saveKeyFile(mqttCAFile, mqttSSLCA);
+          //sendParam = true;
         }
-
+        
         //**************************************
         char *keyWordmqsen = strstr(rxBuffer, "#mqsen");
         if (keyWordmqsen != NULL) {
@@ -1070,7 +1096,7 @@ void initBluetooth() {
   macAddressString = WiFi.macAddress();
   Serial.println("Starting Config Mode");
   BLEDevice::init("trigBoard");
-
+  BLEDevice::setMTU(517); // BT has a 5 byte header. This gives us 512 usable
   // Create the BLE Server
   pServer = BLEDevice::createServer();
   pServer->setCallbacks(new MyServerCallbacks());
@@ -1100,17 +1126,60 @@ void initBluetooth() {
   // Start advertising
   pServer->getAdvertising()->start();
   Serial.println("Waiting for bluetooth connection...");
-
 }
 
 void transmitData(char *prefix, char *dataTx) {
-  char txString[100];
+  // Max 512B plus null terminator
+  char txString[513];
   //  Serial.print(dataTx);
   //  Serial.print(" ");
+  
   sprintf(txString, "%s,%s", prefix, dataTx);
-  //Serial.println(txString);
+  // Serial.println(txString);
+  // Serial.println(strlen(txString));
   pTxCharacteristic->setValue(txString);
   pTxCharacteristic->notify();
+}
+
+void packetizeBluetoothMessage(char *header, char *suffix, char *dataToSend) {
+  Serial.println("Sending bluetooth packet...");
+  size_t dataSize = strlen(dataToSend);
+  size_t fullHeaderLen = strlen(header) + strlen(suffix) + 1; // add a slot for our new comma
+  size_t totalTransmission = fullHeaderLen + dataSize; // leave only one null terminator
+  char fullHeader[fullHeaderLen + 1]; // pad null terminator
+  sprintf(fullHeader, "%s,%s", header, suffix);
+  
+  // Leave space for the extra comma in transmitData
+  // We can move 511B here, plus 1B (comma) transmitData also creates
+  if(totalTransmission <= 511) {  
+    transmitData(fullHeader, dataToSend); 
+    return;
+  }
+  // Max bluetooth transmission per packet is 512
+  // Leave space for the extra comma in transmitData
+  // Restrict our local string to 511B
+  size_t bodyLength = (511 - fullHeaderLen); 
+  size_t remainderLength = dataSize - bodyLength;
+  char body[bodyLength + 1];  // pad null terminator
+  char remainder[remainderLength + 1];  // pad null terminator
+  int i;
+  int r;
+  for(i = 0; i < bodyLength; i++) {
+    body[i] = dataToSend[i];
+  }
+  body[i] = '\0';
+  for(r = 0; r < remainderLength; r++) {
+    remainder[r] = dataToSend[i];
+    i++;
+  }
+  remainder[r] = '\0';
+  //Serial.print("Total length: ");
+  //Serial.print(strlen(fullHeader) + strlen(body));
+  //Serial.print("B\n");
+  transmitData(fullHeader, body);
+  delay(25);
+  packetizeBluetoothMessage(header, "a", remainder);
+  return;
 }
 
 void serviceBluetooth() {
@@ -1213,12 +1282,17 @@ void serviceBluetooth() {
     delay(25);
     transmitData("mqsp", config.mqttPW);
     delay(25);
-    transmitData("mqsske", config.mqttSSLKey);
+    
+    //------------------------------------------
+    //break these into 512 byte chunks
+    packetizeBluetoothMessage("mqsske", "w", mqttSSLKey);
     delay(25);
-    transmitData("mqssce", config.mqttSSLCert);
+    packetizeBluetoothMessage("mqssce", "w", mqttSSLCert);
     delay(25);
-    transmitData("mqssca", config.mqttSSLCA);
+    packetizeBluetoothMessage("mqssca", "w", mqttSSLCA);
     delay(25);
+    //------------------------------------------
+    
     transmitData("sipen", config.staticIPenable);
     delay(25);
     transmitData("sip", config.staticIP);

--- a/bluetooth.ino
+++ b/bluetooth.ino
@@ -593,31 +593,24 @@ class MyCallbacks: public BLECharacteristicCallbacks {
         //**************************************
         char *keyWordmqsslke = strstr(rxBuffer, "#mqsslke");
         if (keyWordmqsslke != NULL) {
-          Serial.println("Got part of a key");
           const char delimiter[] = ",";
           char parsedStrings[3][600];
           char *token =  strtok(rxBuffer, delimiter);
-          Serial.println("DEBUG1");
           strncpy(parsedStrings[0], token, sizeof(parsedStrings[0]));//first one
-          Serial.println("DEBUG2");
           for (int i = 1; i < 3; i++) {
             token =  strtok(NULL, delimiter);
             strncpy(parsedStrings[i], token, sizeof(parsedStrings[i]));
           }
-          Serial.println("DEBUG3");
           if(strcmp(parsedStrings[1], "w") == 0) {
-            Serial.println("DEBUG4");
             strlcpy(mqttSSLKey,                  // <- destination
                   parsedStrings[2],  // <- source
                   sizeof(mqttSSLKey));         // <- destination's capacity
           } else {
             //add some logic in here to resend all params when done
-            Serial.println("DEBUG5");
             strlcat(mqttSSLKey,                  // <- destination
                   parsedStrings[2],  // <- source
                   sizeof(mqttSSLKey));         // <- destination's capacity
           }
-          Serial.println("DEBUG6");
 
           saveKeyFile(mqttKeyFile, mqttSSLKey);
           //sendParam = true;

--- a/configuration.ino
+++ b/configuration.ino
@@ -4,7 +4,7 @@ void loadConfiguration(const char *filename, Config &config) {
   if (SPIFFS.begin(true)) {
     File file = SPIFFS.open(filename, "r");
 
-    StaticJsonDocument<3000> doc;
+    StaticJsonDocument<11000> doc;
     DeserializationError error = deserializeJson(doc, file);
     if (error) {
       Serial.println(F("Failed to read file"));
@@ -137,6 +137,15 @@ void loadConfiguration(const char *filename, Config &config) {
     strlcpy(config.mqttPW,                  // <- destination
             doc["mqttPW"] | "password",  // <- source
             sizeof(config.mqttPW));         // <- destination's capacity
+    strlcpy(config.mqttSSLKey,                  // <- destination
+            doc["mqttSSLKey"] | "",  // <- source
+            sizeof(config.mqttSSLKey));         // <- destination's capacity
+    strlcpy(config.mqttSSLCert,                  // <- destination
+            doc["mqttSSLCert"] | "",  // <- source
+            sizeof(config.mqttSSLCert));         // <- destination's capacity
+    strlcpy(config.mqttSSLCA,                  // <- destination
+            doc["mqttSSLCA"] | "",  // <- source
+            sizeof(config.mqttSSLCA));         // <- destination's capacity
     strlcpy(config.staticIPenable,                  // <- destination
             doc["staticIPenable"] | "f",  // <- source
             sizeof(config.staticIPenable));         // <- destination's capacity
@@ -244,7 +253,7 @@ void saveConfiguration(const char *filename, const Config &config) {
       Serial.println(F("Failed to create file"));
       return;
     }
-    StaticJsonDocument<2000> doc;
+    StaticJsonDocument<11000> doc;
 
     // Set the values in the document
     doc["ssid"] = config.ssid;
@@ -289,6 +298,9 @@ void saveConfiguration(const char *filename, const Config &config) {
     doc["mqttSecureEnable"] =  config.mqttSecureEnable;
     doc["mqttUser"] =  config.mqttUser;
     doc["mqttPW"] =  config.mqttPW;
+    doc["mqttSSLKey"] =  config.mqttSSLKey;
+    doc["mqttSSLCert"] =  config.mqttSSLCert;
+    doc["mqttSSLCA"] =  config.mqttSSLCA;
     doc["staticIPenable"] =  config.staticIPenable;
     doc["staticIP"] =  config.staticIP;
     doc["staticGatewayAddress"] =  config.staticGatewayAddress;

--- a/configuration.ino
+++ b/configuration.ino
@@ -4,7 +4,7 @@ void loadConfiguration(const char *filename, Config &config) {
   if (SPIFFS.begin(true)) {
     File file = SPIFFS.open(filename, "r");
 
-    StaticJsonDocument<11000> doc;
+    StaticJsonDocument<3000> doc;
     DeserializationError error = deserializeJson(doc, file);
     if (error) {
       Serial.println(F("Failed to read file"));
@@ -137,15 +137,6 @@ void loadConfiguration(const char *filename, Config &config) {
     strlcpy(config.mqttPW,                  // <- destination
             doc["mqttPW"] | "password",  // <- source
             sizeof(config.mqttPW));         // <- destination's capacity
-    strlcpy(config.mqttSSLKey,                  // <- destination
-            doc["mqttSSLKey"] | "",  // <- source
-            sizeof(config.mqttSSLKey));         // <- destination's capacity
-    strlcpy(config.mqttSSLCert,                  // <- destination
-            doc["mqttSSLCert"] | "",  // <- source
-            sizeof(config.mqttSSLCert));         // <- destination's capacity
-    strlcpy(config.mqttSSLCA,                  // <- destination
-            doc["mqttSSLCA"] | "",  // <- source
-            sizeof(config.mqttSSLCA));         // <- destination's capacity
     strlcpy(config.staticIPenable,                  // <- destination
             doc["staticIPenable"] | "f",  // <- source
             sizeof(config.staticIPenable));         // <- destination's capacity
@@ -233,16 +224,90 @@ void loadConfiguration(const char *filename, Config &config) {
             doc["timerCheck"] | "f",  // <- source
             sizeof(config.timerCheck));         // <- destination's capacity
 
-
     config.secondsAfterToCheckAgain = doc["secondsAfterToCheckAgain"] | 5;
 
     file.close();
+
+    readKeyFileInto(mqttKeyFile, mqttSSLKey, sizeof(mqttSSLKey));
+    Serial.println("Read key file...");
+    //Serial.println(mqttSSLKey);    
+
+    readKeyFileInto(mqttCertFile, mqttSSLCert, sizeof(mqttSSLCert));
+    Serial.println("Read cert file...");
+    //Serial.println(mqttSSLCert);
+
+    readKeyFileInto(mqttCAFile, mqttSSLCA, sizeof(mqttSSLCert));
+    Serial.println("Read ca file...");
+    //Serial.println(mqttSSLCA);
+    
   } else {
     Serial.println(F("SPIFFS fault"));
     killPower();
   }
 }
 
+void saveKeyFile(const char *filename, const char *value) {
+  if (!SPIFFS.begin(true)) {
+    return;
+  }
+  //Serial.println("Attempting key file write");
+  //Serial.println(filename);
+  File keyFile = SPIFFS.open(filename, "w");
+  if (!keyFile) {
+    Serial.println("Error, no key file for writing");
+  } else {
+    //Serial.println(value);
+    int keyBytesWritten = keyFile.print(value);
+    keyFile.close(); 
+    if (keyBytesWritten > 0) {
+      //Serial.println("Key file was written");
+      //Serial.println(keyBytesWritten);
+    } else {
+      SPIFFS.remove(filename);
+      //Serial.println("Key is blank");
+    } 
+  }
+  //Serial.println("Wrote to key file...");
+  //Serial.println(filename);
+  return;
+}
+
+void readKeyFileInto(const char *filename, char *outValue, size_t outSize) {
+  if (!SPIFFS.begin(true)) {
+    return;
+  }
+  File keyFile = SPIFFS.open(filename, "r");
+  if(keyFile) {
+    size_t keyFileSize = keyFile.size(); //the size of the file in bytes   
+    char keyString[keyFileSize];   // + 1 for '\0' char at the end
+    //Serial.print("Key file size: ");
+    //Serial.print(keyFileSize);
+    //Serial.print("\n");
+    //Serial.print("Max output size: ");
+    //Serial.print(outSize);
+    //Serial.print("\n");
+    if(keyFileSize <= outSize) {
+      uint16_t k = 0;
+      while(keyFile.available()){
+         keyString[k] = keyFile.read();
+         k++;
+      }
+      keyString[k] = '\0';
+      //Serial.print("Read ");
+      //Serial.print(k);
+      //Serial.print(" bytes\n");
+    }
+    keyFile.close();
+    strlcpy(outValue,                  // <- destination
+            keyString,  // <- source
+            outSize);         // <- destination's capacity 
+  } else {
+    strlcpy(outValue,                  // <- destination
+            "",  // <- source
+            outSize);         // <- destination's capacity
+  }
+  return;
+}
 
 void saveConfiguration(const char *filename, const Config &config) {
 
@@ -253,7 +318,7 @@ void saveConfiguration(const char *filename, const Config &config) {
       Serial.println(F("Failed to create file"));
       return;
     }
-    StaticJsonDocument<11000> doc;
+    StaticJsonDocument<3000> doc;
 
     // Set the values in the document
     doc["ssid"] = config.ssid;
@@ -298,9 +363,6 @@ void saveConfiguration(const char *filename, const Config &config) {
     doc["mqttSecureEnable"] =  config.mqttSecureEnable;
     doc["mqttUser"] =  config.mqttUser;
     doc["mqttPW"] =  config.mqttPW;
-    doc["mqttSSLKey"] =  config.mqttSSLKey;
-    doc["mqttSSLCert"] =  config.mqttSSLCert;
-    doc["mqttSSLCA"] =  config.mqttSSLCA;
     doc["staticIPenable"] =  config.staticIPenable;
     doc["staticIP"] =  config.staticIP;
     doc["staticGatewayAddress"] =  config.staticGatewayAddress;
@@ -337,10 +399,6 @@ void saveConfiguration(const char *filename, const Config &config) {
     }
 
     // Close the file
-    file.close();
-
-
+    file.close();  
   }
-
-
 }

--- a/includes.h
+++ b/includes.h
@@ -89,6 +89,9 @@ struct Config {//full configuration file
   char mqttSecureEnable[3];
   char mqttUser[50];
   char mqttPW[50];
+  char mqttSSLKey[2000];
+  char mqttSSLCert[2000];
+  char mqttSSLCA[2000];
   char staticIPenable[3];
   char staticIP[20];
   char staticGatewayAddress[20];

--- a/includes.h
+++ b/includes.h
@@ -89,9 +89,6 @@ struct Config {//full configuration file
   char mqttSecureEnable[3];
   char mqttUser[50];
   char mqttPW[50];
-  char mqttSSLKey[2000];
-  char mqttSSLCert[2000];
-  char mqttSSLCA[2000];
   char staticIPenable[3];
   char staticIP[20];
   char staticGatewayAddress[20];
@@ -154,7 +151,14 @@ bool buttonWasPressed;
 bool contactChanged = false;
 bool wiFiNeeded = false;
 Config config;
-
+// mqtt ssl key files and global in-memory strings
+const size_t mqttMaxKeyLength = 3001;
+char mqttSSLKey[mqttMaxKeyLength];
+char mqttSSLCert[mqttMaxKeyLength];
+char mqttSSLCA[mqttMaxKeyLength];
+const char *mqttKeyFile = "/key.pem";
+const char *mqttCertFile = "/cert.pem";
+const char *mqttCAFile = "/ca.pem";
 //rtc
 char rtcTimeStamp[20];
 bool checkAgainSet = false;

--- a/mqtt.ino
+++ b/mqtt.ino
@@ -10,29 +10,34 @@ void callback(char* topic, byte* payload, unsigned int length) {
   Serial.println();
 }
 
-//PubSubClient getClient () {
-//  if (strcmp(config.mqttSecureEnable, "t") == 0 && strlen(config.mqttSSLKey) > 0 && strlen(config.mqttSSLCert) > 0 && strlen(config.mqttSSLCA) > 0) {
-//    WiFiClientSecure espClient;
-//    espClient.setCACert(config.mqttSSLCA);
-//    espClient.setCertificate(config.mqttSSLCert); // for client verification
-//    espClient.setPrivateKey(config.mqttSSLKey);  
-//    espClient.setInsecure();
-//    PubSubClient client(espClient);
-//    return client;
-//  } else {
-//    WiFiClient espClient;
-//    PubSubClient client(espClient);
-//    return client;
-//  }
-//}
-
 void mqtt() {
   if (strcmp(config.mqttEnable, "t") == 0) {//only if enabled
     
     Serial.println("sending mqtt");
 
-    WiFiClient espClient;
-    PubSubClient client(espClient);
+    PubSubClient client;
+    WiFiClientSecure secureClient;
+    WiFiClient insecureClient;
+    bool hasKey = strlen(mqttSSLKey) > 0;
+    bool hasCert = strlen(mqttSSLCert) > 0;
+    bool hasCA = strlen(mqttSSLCA) > 0;
+    bool isSSL = (hasKey && hasCert) || (!hasKey && !hasCert && hasCA);
+    if (strcmp(config.mqttSecureEnable, "t") == 0 && isSSL) {
+      if(hasKey) {
+        secureClient.setPrivateKey(mqttSSLKey); // for PKI encryption
+      }
+      if(hasCert) {
+        secureClient.setCertificate(mqttSSLCert); // for x509 client verification
+      }
+      if(hasCA) {
+        secureClient.setCACert(mqttSSLCA); // for signing trust
+      }
+      secureClient.setInsecure();
+      client.setClient(secureClient);
+    } else {
+      client.setClient(insecureClient);
+    }    
+    
     client.setServer(config.mqttServer, config.mqttPort);
     client.setCallback(callback);
     unsigned long mqttStart = millis();

--- a/mqtt.ino
+++ b/mqtt.ino
@@ -16,6 +16,8 @@ void mqtt() {
     
     Serial.println("sending mqtt");
 
+    //WiFiClientSecure client;
+    //client.setInsecure();//trigger this with a config var, enable one-way mqtt ssl
     WiFiClient espClient;
     PubSubClient client(espClient);
     client.setServer(config.mqttServer, config.mqttPort);

--- a/mqtt.ino
+++ b/mqtt.ino
@@ -10,14 +10,27 @@ void callback(char* topic, byte* payload, unsigned int length) {
   Serial.println();
 }
 
+//PubSubClient getClient () {
+//  if (strcmp(config.mqttSecureEnable, "t") == 0 && strlen(config.mqttSSLKey) > 0 && strlen(config.mqttSSLCert) > 0 && strlen(config.mqttSSLCA) > 0) {
+//    WiFiClientSecure espClient;
+//    espClient.setCACert(config.mqttSSLCA);
+//    espClient.setCertificate(config.mqttSSLCert); // for client verification
+//    espClient.setPrivateKey(config.mqttSSLKey);  
+//    espClient.setInsecure();
+//    PubSubClient client(espClient);
+//    return client;
+//  } else {
+//    WiFiClient espClient;
+//    PubSubClient client(espClient);
+//    return client;
+//  }
+//}
 
 void mqtt() {
   if (strcmp(config.mqttEnable, "t") == 0) {//only if enabled
     
     Serial.println("sending mqtt");
 
-    //WiFiClientSecure client;
-    //client.setInsecure();//trigger this with a config var, enable one-way mqtt ssl
     WiFiClient espClient;
     PubSubClient client(espClient);
     client.setServer(config.mqttServer, config.mqttPort);

--- a/trigBoardV8_BaseFirmware.ino
+++ b/trigBoardV8_BaseFirmware.ino
@@ -1,7 +1,7 @@
 #define OTA_DEBUG
 #include "includes.h"
 
-const char fwVersion[] = "06/11/22";
+const char fwVersion[] = "06/12/22";
 
 void setup() {
 
@@ -13,7 +13,6 @@ void setup() {
   checkWakeupPins();
   loadConfiguration(filename, config);
   rtcInit(config.timerCountDown, false);
-  
   
   Serial.println(getBattery(), 2);
   if (pushLogic()) { //decide if push will occur or nt and what message will be

--- a/trigBoardV8_BaseFirmware.ino
+++ b/trigBoardV8_BaseFirmware.ino
@@ -1,7 +1,7 @@
 #define OTA_DEBUG
 #include "includes.h"
 
-const char fwVersion[] = "11/29/21";
+const char fwVersion[] = "06/11/22";
 
 void setup() {
 


### PR DESCRIPTION
-Adds new storage locations for mqtt key/cert/ca
-Adds bluetooth "chunking" proof-of-concept
-Declares BT MTU size as 517B (5 bytes header + 512 bytes data)
-Adds generic function `packetizeBluetoothMessage` which can chunk data back to the configurator
-Adds mqtt module condition to choose HTTPS with certs present
-Adds generic key file read/save functions